### PR TITLE
added `-r` option for removing all directories

### DIFF
--- a/dmux.sh
+++ b/dmux.sh
@@ -81,7 +81,7 @@ case "$1" in
 			rm -r /tmp/dmux/workdir-*
 		else # Remove one container
 			docker rm "dmux-$2"
-			rm "/tmp/dmux/workdir-dmux-$2"
+			rm -r "/tmp/dmux/workdir-dmux-$2"
 		fi
 		;;
 	# List dmux containers
@@ -92,7 +92,7 @@ case "$1" in
 	"v")
 		infer_container_name "$@"
 		# Delete the sym link
-		rm "/tmp/dmux/workdir-$CONTAINER_NAME"
+		rm -r "/tmp/dmux/workdir-$CONTAINER_NAME"
 		# Create a new one
 		echo "Remounting $CONTAINER_NAME workdir to $(pwd)"
 		ln -s "$(pwd)" "/tmp/dmux/workdir-$CONTAINER_NAME"


### PR DESCRIPTION
sometimes when I try to `dmux v` I get an error stating `rm` cannot remove `/tmp/dmux/workdir-*` since it is a directory. I think passing `-r` to `rm` whenever we are removing a directory will fix this issue.